### PR TITLE
Removing namespace pollution & rf ctrls refactor

### DIFF
--- a/SX1272/SX1272_LoRaRadio.h
+++ b/SX1272/SX1272_LoRaRadio.h
@@ -26,22 +26,23 @@ SPDX-License-Identifier: BSD-3-Clause
 #ifndef SX1272_LORARADIO_H_
 #define SX1272_LORARADIO_H_
 
+#include "PinNames.h"
+#include "InterruptIn.h"
+#include "DigitalOut.h"
+#include "DigitalInOut.h"
+#include "SPI.h"
+#include "Timeout.h"
+#ifdef MBED_CONF_RTOS_PRESENT
+ #include "rtos/Thread.h"
+#endif
 #include "netsocket/LoRaRadio.h"
+
 
 #ifdef MBED_SX1272_LORARADIO_BUFFER_SIZE
 #define MAX_DATA_BUFFER_SIZE                        MBED_SX1272_LORARADIO_BUFFER_SIZE
 #else
 #define MAX_DATA_BUFFER_SIZE                        256
 #endif
-
-typedef struct {
-    PinName rf_switch_ctl1;
-    PinName rf_switch_ctl2;
-    PinName txctl;
-    PinName rxctl;
-    PinName ant_switch;
-    PinName pwr_amp_ctl;
-} rf_ctrls;
 
 /**
  * Radio driver implementation for Semtech SX1272 plus variants.
@@ -301,27 +302,27 @@ public:
 private:
 
     // SPI and chip select control
-    SPI _spi;
-    DigitalOut _chip_select;
+    mbed::SPI _spi;
+    mbed::DigitalOut _chip_select;
 
     // module rest control
-    DigitalInOut _reset_ctl;
+    mbed::DigitalInOut _reset_ctl;
 
     // Interrupt controls
-    InterruptIn _dio0_ctl;
-    InterruptIn _dio1_ctl;
-    InterruptIn _dio2_ctl;
-    InterruptIn _dio3_ctl;
-    InterruptIn _dio4_ctl;
-    InterruptIn _dio5_ctl;
+    mbed::InterruptIn _dio0_ctl;
+    mbed::InterruptIn _dio1_ctl;
+    mbed::InterruptIn _dio2_ctl;
+    mbed::InterruptIn _dio3_ctl;
+    mbed::InterruptIn _dio4_ctl;
+    mbed::InterruptIn _dio5_ctl;
 
     // Radio specific controls
-    DigitalOut _rf_switch_ctl1;
-    DigitalOut _rf_switch_ctl2;
-    DigitalOut _txctl;
-    DigitalOut _rxctl;
-    DigitalInOut _ant_switch;
-    DigitalOut _pwr_amp_ctl;
+    mbed::DigitalOut _rf_switch_ctl1;
+    mbed::DigitalOut _rf_switch_ctl2;
+    mbed::DigitalOut _txctl;
+    mbed::DigitalOut _rxctl;
+    mbed::DigitalInOut _ant_switch;
+    mbed::DigitalOut _pwr_amp_ctl;
 
     // Contains all RF control pin names
     // This storage is needed even after assigning the
@@ -343,13 +344,13 @@ private:
     uint8_t _data_buffer[MAX_DATA_BUFFER_SIZE];
 
     // TX/RX Timers - all use milisecond units
-    Timeout tx_timeout_timer;
-    Timeout rx_timeout_timer;
-    Timeout rx_timeout_sync_word;
+    mbed::Timeout tx_timeout_timer;
+    mbed::Timeout rx_timeout_timer;
+    mbed::Timeout rx_timeout_sync_word;
 
 #ifdef MBED_CONF_RTOS_PRESENT
     // Thread to handle interrupts
-    Thread irq_thread;
+    rtos::Thread irq_thread;
 #endif
 
     // Access protection

--- a/SX1276/SX1276_LoRaRadio.h
+++ b/SX1276/SX1276_LoRaRadio.h
@@ -26,6 +26,15 @@ SPDX-License-Identifier: BSD-3-Clause
 #ifndef SX1276_LORARADIO_H_
 #define SX1276_LORARADIO_H_
 
+#include "PinNames.h"
+#include "InterruptIn.h"
+#include "DigitalOut.h"
+#include "DigitalInOut.h"
+#include "SPI.h"
+#include "Timeout.h"
+#ifdef MBED_CONF_RTOS_PRESENT
+ #include "rtos/Thread.h"
+#endif
 #include "netsocket/LoRaRadio.h"
 
 #ifdef MBED_SX1276_LORARADIO_BUFFER_SIZE
@@ -33,16 +42,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #else
 #define MAX_DATA_BUFFER_SIZE                        256
 #endif
-
-typedef struct {
-    PinName rf_switch_ctl1;
-    PinName rf_switch_ctl2;
-    PinName txctl;
-    PinName rxctl;
-    PinName ant_switch;
-    PinName pwr_amp_ctl;
-    PinName tcxo;
-} rf_ctrls;
 
 /**
  * Radio driver implementation for Semtech SX1272 plus variants.
@@ -318,28 +317,28 @@ public:
 private:
 
     // SPI and chip select control
-    SPI _spi;
-    DigitalOut _chip_select;
+    mbed::SPI _spi;
+    mbed::DigitalOut _chip_select;
 
     // module rest control
-    DigitalInOut _reset_ctl;
+    mbed::DigitalInOut _reset_ctl;
 
     // Interrupt controls
-    InterruptIn _dio0_ctl;
-    InterruptIn _dio1_ctl;
-    InterruptIn _dio2_ctl;
-    InterruptIn _dio3_ctl;
-    InterruptIn _dio4_ctl;
-    InterruptIn _dio5_ctl;
+    mbed::InterruptIn _dio0_ctl;
+    mbed::InterruptIn _dio1_ctl;
+    mbed::InterruptIn _dio2_ctl;
+    mbed::InterruptIn _dio3_ctl;
+    mbed::InterruptIn _dio4_ctl;
+    mbed::InterruptIn _dio5_ctl;
 
     // Radio specific controls
-    DigitalOut _rf_switch_ctl1;
-    DigitalOut _rf_switch_ctl2;
-    DigitalOut _txctl;
-    DigitalOut _rxctl;
-    DigitalInOut _ant_switch;
-    DigitalOut _pwr_amp_ctl;
-    DigitalOut _tcxo;
+    mbed::DigitalOut _rf_switch_ctl1;
+    mbed::DigitalOut _rf_switch_ctl2;
+    mbed::DigitalOut _txctl;
+    mbed::DigitalOut _rxctl;
+    mbed::DigitalInOut _ant_switch;
+    mbed::DigitalOut _pwr_amp_ctl;
+    mbed::DigitalOut _tcxo;
 
     // Contains all RF control pin names
     // This storage is needed even after assigning the
@@ -361,13 +360,13 @@ private:
     uint8_t _data_buffer[MAX_DATA_BUFFER_SIZE];
 
     // TX/RX Timers - all use milisecond units
-    Timeout tx_timeout_timer;
-    Timeout rx_timeout_timer;
-    Timeout rx_timeout_sync_word;
+    mbed::Timeout tx_timeout_timer;
+    mbed::Timeout rx_timeout_timer;
+    mbed::Timeout rx_timeout_sync_word;
 
 #ifdef MBED_CONF_RTOS_PRESENT
     // Thread to handle interrupts
-    Thread irq_thread;
+    rtos::Thread irq_thread;
 #endif
 
     // Access protection
@@ -419,6 +418,5 @@ private:
     void handle_dio4_irq();
     void handle_dio5_irq();
     void handle_timeout_irq();
-};
 
 #endif // SX1276_LORARADIO_H_


### PR DESCRIPTION
rf_ctrls is a data structure that holds all control pins for a certain LoRa Radio.
Same data structure was being used in both SX1272 and SX1276 drivers. As we are
heading towards putting both drivers in the same repo and as the plan is to use them
togather, i.e., both header files could be included we need to move this data structure to a
common location so that the name does not collide.

In addition to that we have tried to reduce namespace pollution caused by the driver
header files.