### PR TITLE
Buffer Size and missing terminator for SX127 class

### DIFF
--- a/SX1272/SX1272_LoRaRadio.cpp
+++ b/SX1272/SX1272_LoRaRadio.cpp
@@ -953,7 +953,7 @@ void SX1272_LoRaRadio::receive(uint32_t timeout)
             break;
     }
 
-    memset(_data_buffer, 0, (size_t) MAX_DATA_BUFFER_SIZE);
+    memset(_data_buffer, 0, (size_t) MAX_DATA_BUFFER_SIZE_SX172);
 
     _rf_settings.state = RF_RX_RUNNING;
 

--- a/SX1272/SX1272_LoRaRadio.h
+++ b/SX1272/SX1272_LoRaRadio.h
@@ -38,10 +38,10 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "netsocket/LoRaRadio.h"
 
 
-#ifdef MBED_SX1272_LORARADIO_BUFFER_SIZE
-#define MAX_DATA_BUFFER_SIZE                        MBED_SX1272_LORARADIO_BUFFER_SIZE
+#ifdef MBED_CONF_SX1272_LORA_DRIVER_BUFFER_SIZE
+#define MAX_DATA_BUFFER_SIZE_SX172                        MBED_CONF_SX1272_LORA_DRIVER_BUFFER_SIZE
 #else
-#define MAX_DATA_BUFFER_SIZE                        256
+#define MAX_DATA_BUFFER_SIZE_SX172                        256
 #endif
 
 /**
@@ -341,7 +341,7 @@ private:
     // Data buffer used for both TX and RX
     // Size of this buffer is configurable via Mbed config system
     // Default is 256 bytes
-    uint8_t _data_buffer[MAX_DATA_BUFFER_SIZE];
+    uint8_t _data_buffer[MAX_DATA_BUFFER_SIZE_SX172];
 
     // TX/RX Timers - all use milisecond units
     mbed::Timeout tx_timeout_timer;

--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -978,7 +978,7 @@ void SX1276_LoRaRadio::receive(uint32_t timeout)
             break;
     }
 
-    memset(_data_buffer, 0, (size_t) MAX_DATA_BUFFER_SIZE);
+    memset(_data_buffer, 0, (size_t) MAX_DATA_BUFFER_SIZE_SX1276);
 
     _rf_settings.state = RF_RX_RUNNING;
 

--- a/SX1276/SX1276_LoRaRadio.h
+++ b/SX1276/SX1276_LoRaRadio.h
@@ -37,10 +37,10 @@ SPDX-License-Identifier: BSD-3-Clause
 #endif
 #include "netsocket/LoRaRadio.h"
 
-#ifdef MBED_SX1276_LORARADIO_BUFFER_SIZE
-#define MAX_DATA_BUFFER_SIZE                        MBED_SX1276_LORARADIO_BUFFER_SIZE
+#ifdef MBED_CONF_SX1276_LORA_DRIVER_BUFFER_SIZE
+#define MAX_DATA_BUFFER_SIZE_SX1276                        MBED_CONF_SX1276_LORA_DRIVER_BUFFER_SIZE
 #else
-#define MAX_DATA_BUFFER_SIZE                        256
+#define MAX_DATA_BUFFER_SIZE_SX1276                        256
 #endif
 
 /**
@@ -357,7 +357,7 @@ private:
     // Data buffer used for both TX and RX
     // Size of this buffer is configurable via Mbed config system
     // Default is 256 bytes
-    uint8_t _data_buffer[MAX_DATA_BUFFER_SIZE];
+    uint8_t _data_buffer[MAX_DATA_BUFFER_SIZE_SX1276];
 
     // TX/RX Timers - all use milisecond units
     mbed::Timeout tx_timeout_timer;
@@ -418,5 +418,6 @@ private:
     void handle_dio4_irq();
     void handle_dio5_irq();
     void handle_timeout_irq();
+};
 
 #endif // SX1276_LORARADIO_H_


### PR DESCRIPTION
For some unknown reason (may be a rebase issue) Mbed config name for the
drivers was not spell correctly inside the source macro definition.
Alongwith that the SX1276 driver was missing a class terminator.