### PR TITLE
Set up DIO4 and 5 interrupts only if pins are connected

### DIFF
--- a/SX1272/SX1272_LoRaRadio.cpp
+++ b/SX1272/SX1272_LoRaRadio.cpp
@@ -185,6 +185,7 @@ SX1272_LoRaRadio::SX1272_LoRaRadio(PinName spi_mosi, PinName spi_miso,
     _rf_ctrls.rxctl = rxctl;
     _rf_ctrls.txctl = txctl;
 
+    _dio4_pin = dio4;
     _dio5_pin = dio5;
 
     _radio_events = NULL;
@@ -1579,7 +1580,9 @@ void SX1272_LoRaRadio::setup_interrupts()
     _dio1_ctl.rise(callback(this, &SX1272_LoRaRadio::dio1_irq_isr));
     _dio2_ctl.rise(callback(this, &SX1272_LoRaRadio::dio2_irq_isr));
     _dio3_ctl.rise(callback(this, &SX1272_LoRaRadio::dio3_irq_isr));
-    _dio4_ctl.rise(callback(this, &SX1272_LoRaRadio::dio4_irq_isr));
+    if (_dio4_pin != NC) {
+        _dio4_ctl.rise(callback(this, &SX1272_LoRaRadio::dio4_irq_isr));
+    }
     if (_dio5_pin != NC) {
         _dio5_ctl.rise(callback(this, &SX1272_LoRaRadio::dio5_irq_isr));
     }
@@ -1591,7 +1594,6 @@ void SX1272_LoRaRadio::setup_interrupts()
  */
 void SX1272_LoRaRadio::set_low_power_mode(bool status)
 {
-
     if( RadioIsActive != status )
     {
         RadioIsActive = status;

--- a/SX1272/SX1272_LoRaRadio.h
+++ b/SX1272/SX1272_LoRaRadio.h
@@ -331,7 +331,8 @@ private:
     // variation is inherent to driver because of target configuration.
     rf_ctrls _rf_ctrls;
 
-    // DIO5 PinName. We need to store this as not all modules have it connected
+    // We need these PinNames as not all modules have those connected
+    PinName _dio4_pin;
     PinName _dio5_pin;
 
     // Structure containing all user and network specified settings

--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -184,6 +184,9 @@ SX1276_LoRaRadio::SX1276_LoRaRadio(PinName spi_mosi, PinName spi_miso,
     _rf_ctrls.txctl = txctl;
     _rf_ctrls.tcxo = tcxo;
 
+    _dio4_pin = dio4;
+    _dio5_pin = dio5;
+
     _radio_events = NULL;
 
     // Detect Murata based on pin configuration
@@ -1662,8 +1665,10 @@ void SX1276_LoRaRadio::setup_interrupts()
     _dio1_ctl.rise(callback(this, &SX1276_LoRaRadio::dio1_irq_isr));
     _dio2_ctl.rise(callback(this, &SX1276_LoRaRadio::dio2_irq_isr));
     _dio3_ctl.rise(callback(this, &SX1276_LoRaRadio::dio3_irq_isr));
-    _dio4_ctl.rise(callback(this, &SX1276_LoRaRadio::dio4_irq_isr));
-    if (!is_murata) {
+    if (_dio4_pin != NC) {
+        _dio4_ctl.rise(callback(this, &SX1276_LoRaRadio::dio4_irq_isr));
+    }
+    if (_dio5_pin != NC) {
         _dio5_ctl.rise(callback(this, &SX1276_LoRaRadio::dio5_irq_isr));
     }
 }

--- a/SX1276/SX1276_LoRaRadio.h
+++ b/SX1276/SX1276_LoRaRadio.h
@@ -347,6 +347,10 @@ private:
     // variation is inherent to driver because of target configuration.
     rf_ctrls _rf_ctrls;
 
+    // We need these PinNames as not all modules have those connected
+    PinName _dio4_pin;
+    PinName _dio5_pin;
+
     // Structure containing all user and network specified settings
     // for radio module
     radio_settings_t _rf_settings;


### PR DESCRIPTION
For example muRata modules do not have DIO4 and DIO5 pins connected.
If these pins are not connected, driver should not try to set up
interrupt handlers for those.