### PR TITLE
Change WISE-1510 target to new name

### DIFF
--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -1454,7 +1454,7 @@ uint8_t SX1276_LoRaRadio::get_fsk_bw_reg_val(uint32_t bandwidth)
 
 uint8_t SX1276_LoRaRadio::get_pa_conf_reg(uint32_t channel)
 {
-#if TARGET_WISE_1510
+#if TARGET_MTB_ADV_WISE_1510
     return RF_PACONFIG_PASELECT_PABOOST;
 #else
     if (channel > RF_MID_BAND_THRESH) {


### PR DESCRIPTION
To be merged after mbed-os 1c5c1c79d0b518aec629004be19f7fd1fd62fb8e has been taken into use