### PR TITLE
add support for the RFM95 board, fixes #13

### DIFF
--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -213,6 +213,13 @@ SX1276_LoRaRadio::SX1276_LoRaRadio(PinName spi_mosi,
         is_murata = false;
     }
 
+    // Detect RFM95 based on pin configuration
+    if (pwr_amp_ctl == NC && txctl == NC && rxctl == NC && tcxo == NC && antswitch == NC && rf_switch_ctl1 == NC && rf_switch_ctl2 == NC) {
+        is_rfm95 = true;
+    } else {
+        is_rfm95 = false;
+    }
+
     if (tcxo != NC) {
         _tcxo = 1;
     }
@@ -259,7 +266,9 @@ void SX1276_LoRaRadio::init_radio(radio_events_t *events)
     // Reset the radio transceiver
     radio_reset();
 
-    if (!is_murata) {
+    if (is_rfm95) {
+        radio_variant = SX1276MB1LAS;
+    } else if (!is_murata) {
         // Setup radio variant type
         set_sx1276_variant_type();
     }

--- a/SX1276/SX1276_LoRaRadio.h
+++ b/SX1276/SX1276_LoRaRadio.h
@@ -393,6 +393,9 @@ private:
     // Murata board
     bool is_murata;
 
+    // RFM95 board
+    bool is_rfm95;
+
     // helper functions
     void setup_registers();
     void default_antenna_switch_ctrls();


### PR DESCRIPTION
as suggested in #13 , this PR adds support for the RFM95 board. 

Based on the pin configuration (most notably, when the `antswitch == NC`), the RFM95 configuration is detected.  The state is preserved in an `is_rfm95` boolean value, following the same principle and technique that is used for the detection of the murata.

When the RFM95 board is detected, the variant type is set to SX1276MB1LAS, which is compatible, and the `set_sx1276_variant_type()` method is skipped (as it is using the `_ant_switch` pin, that is not present in the RFM95 configuration,  to determine configruation).