### PR TITLE
Change static variables to class members

### DIFF
--- a/SX1272/SX1272_LoRaRadio.cpp
+++ b/SX1272/SX1272_LoRaRadio.cpp
@@ -80,7 +80,7 @@ typedef struct
  */
 typedef struct
 {
-    modem_type   modem;
+    modem_type  modem;
     uint8_t     addr;
     uint8_t     value;
 } radio_registers_t;
@@ -159,12 +159,6 @@ const fsk_bw_t fsk_bandwidths[] =
  */
 static const radio_registers_t radio_reg_init[] = RADIO_INIT_REGISTERS_VALUE;
 
-static uint8_t radio_variant;
-
-/**
- * Flag used to set the RF switch control pins in low power mode when the radio is not active.
- */
-static bool radio_is_active = false;
 
 /**
  * Constructor
@@ -215,6 +209,8 @@ SX1272_LoRaRadio::SX1272_LoRaRadio(PinName spi_mosi,
     if (tcxo != NC) {
         _tcxo = 1;
     }
+
+    radio_is_active = false;
 
 #ifdef MBED_CONF_RTOS_PRESENT
     irq_thread.start(mbed::callback(this, &SX1272_LoRaRadio::rf_irq_task));

--- a/SX1272/SX1272_LoRaRadio.h
+++ b/SX1272/SX1272_LoRaRadio.h
@@ -375,6 +375,13 @@ private:
     // Access protection
     PlatformMutex mutex;
 
+    uint8_t radio_variant;
+
+    /**
+     * Flag used to set the RF switch control pins in low power mode when the radio is not active.
+     */
+    bool radio_is_active;
+
     // helper functions
     void setup_registers();
     void default_antenna_switch_ctrls();

--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -48,8 +48,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #define XTAL_FREQ                                   32000000
 #define FREQ_STEP                                   61.03515625
 
-#define RX_BUFFER_SIZE                              256
-
 /*!
  * Constant values need to compute the RSSI value
  */
@@ -72,7 +70,7 @@ typedef struct
  */
 typedef struct
 {
-    uint8_t   modem;
+    uint8_t     modem;
     uint8_t     addr;
     uint8_t     value;
 } radio_registers_t;
@@ -156,8 +154,6 @@ enum RadioVariant {
 #else
 #define SPI_FREQUENCY    8000000
 #endif
-
-static uint8_t radio_variant;
 
 /**
  * Constructor

--- a/SX1276/SX1276_LoRaRadio.h
+++ b/SX1276/SX1276_LoRaRadio.h
@@ -390,6 +390,8 @@ private:
     // Access protection
     PlatformMutex mutex;
 
+    uint8_t radio_variant;
+
     // helper functions
     void setup_registers();
     void default_antenna_switch_ctrls();


### PR DESCRIPTION
Some variables were still defind as static in sources but as drivers
are now C++ classes, these variables should be members of the class.