### PR TITLE
Remove usage of DEVICE_SPI flag

### DIFF
--- a/SX1272/SX1272_LoRaRadio.cpp
+++ b/SX1272/SX1272_LoRaRadio.cpp
@@ -32,8 +32,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "sx1272Regs-Fsk.h"
 #include "sx1272Regs-LoRa.h"
 
-#ifdef DEVICE_SPI
-
 #if defined(FEATURE_COMMON_PAL)
 #include "mbed_trace.h"
 #define TRACE_GROUP "LRAD"
@@ -2169,6 +2167,3 @@ void SX1272_LoRaRadio::handle_timeout_irq()
          break;
      }
 }
-
-#endif //DEVICE_SPI
-

--- a/SX1272/SX1272_LoRaRadio.h
+++ b/SX1272/SX1272_LoRaRadio.h
@@ -39,8 +39,6 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "lorawan/LoRaRadio.h"
 
-#ifdef DEVICE_SPI
-
 #ifdef MBED_CONF_SX1272_LORA_DRIVER_BUFFER_SIZE
 #define MAX_DATA_BUFFER_SIZE_SX172                        MBED_CONF_SX1272_LORA_DRIVER_BUFFER_SIZE
 #else
@@ -425,7 +423,5 @@ private:
     void handle_dio5_irq();
     void handle_timeout_irq();
 };
-
-#endif //DEVICE_SPI
 
 #endif /* SX1272_LORARADIO_H_ */

--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -30,8 +30,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "sx1276Regs-Fsk.h"
 #include "sx1276Regs-LoRa.h"
 
-#ifdef DEVICE_SPI
-
 /*!
  * Sync word for Private LoRa networks
  */
@@ -2321,6 +2319,3 @@ void SX1276_LoRaRadio::handle_timeout_irq()
     }
 }
 // EOF
-
-#endif //DEVICE_SPI
-

--- a/SX1276/SX1276_LoRaRadio.h
+++ b/SX1276/SX1276_LoRaRadio.h
@@ -45,8 +45,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #define MAX_DATA_BUFFER_SIZE_SX1276                        256
 #endif
 
-#ifdef DEVICE_SPI
-
 /**
  * Radio driver implementation for Semtech SX1272 plus variants.
  * Supports only SPI at the moment. Implements pure virtual LoRaRadio class.
@@ -436,7 +434,5 @@ private:
     void handle_dio5_irq();
     void handle_timeout_irq();
 };
-
-#endif //DEVICE_SPI
 
 #endif // SX1276_LORARADIO_H_


### PR DESCRIPTION
DEVICE_SPI flag is no longer needed as our CI only builds mbed-os-example-lorawan to targets which really have lora hw.