### PR TITLE
Correcting buffer size and tx timer units

### DIFF
--- a/SX1272/SX1272_LoRaRadio.cpp
+++ b/SX1272/SX1272_LoRaRadio.cpp
@@ -1110,7 +1110,7 @@ void SX1272_LoRaRadio::set_tx_continuous_wave(uint32_t freq, int8_t power,
     uint8_t reg_val;
 
     set_channel(freq);
-    set_tx_config(MODEM_FSK, power, 0, 0, 4800, 0, 5, false, false, 0, 0, 0, time);
+    set_tx_config(MODEM_FSK, power, 0, 0, 4800, 0, 5, false, false, 0, 0, 0, time * 1000);
     reg_val = read_register(REG_PACKETCONFIG2);
 
     write_to_register( REG_PACKETCONFIG2, (reg_val & RF_PACKETCONFIG2_DATAMODE_MASK ) );
@@ -1119,7 +1119,7 @@ void SX1272_LoRaRadio::set_tx_continuous_wave(uint32_t freq, int8_t power,
     write_to_register( REG_DIOMAPPING2, RF_DIOMAPPING2_DIO4_10 | RF_DIOMAPPING2_DIO5_10 );
 
     _rf_settings.state = RF_TX_RUNNING;
-    tx_timeout_timer.attach_us(callback(this, &SX1272_LoRaRadio::timeout_irq_isr), time*1e3);
+    tx_timeout_timer.attach_us(callback(this, &SX1272_LoRaRadio::timeout_irq_isr), time * 1000000);
     set_operation_mode(RF_OPMODE_TRANSMITTER);
 }
 

--- a/SX1272/SX1272_LoRaRadio.h
+++ b/SX1272/SX1272_LoRaRadio.h
@@ -42,7 +42,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #ifdef MBED_CONF_SX1272_LORA_DRIVER_BUFFER_SIZE
 #define MAX_DATA_BUFFER_SIZE_SX172                        MBED_CONF_SX1272_LORA_DRIVER_BUFFER_SIZE
 #else
-#define MAX_DATA_BUFFER_SIZE_SX172                        256
+#define MAX_DATA_BUFFER_SIZE_SX172                        255
 #endif
 
 /**
@@ -173,7 +173,7 @@ public:
      *  @param iq_inverted   Inverts IQ signals ( LoRa only )
      *                          FSK : N/A ( set to 0 )
      *                          LoRa: [0: not inverted, 1: inverted]
-     *  @param timeout       Transmission timeout [us]
+     *  @param timeout       Transmission timeout [ms]
      */
     virtual void set_tx_config(radio_modems_t modem, int8_t power, uint32_t fdev,
                               uint32_t bandwidth, uint32_t datarate,

--- a/SX1272/mbed_lib.json
+++ b/SX1272/mbed_lib.json
@@ -6,8 +6,8 @@
         	"value": 8000000
         },
         "buffer-size": {
-        	"help": "Max. buffer size the radio can handle, Default: 256 B",
-        	"value": 256
+        	"help": "Max. buffer size the radio can handle, Default: 255 B",
+        	"value": 255
         }
     }
 }

--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -581,11 +581,8 @@ void SX1276_LoRaRadio::set_tx_config(radio_modems_t modem, int8_t power,
 
         case MODEM_LORA:
             _rf_settings.lora.power = power;
-            if (bandwidth > 2) {
-                // Fatal error: When using LoRa modem only bandwidths 125, 250 and 500 kHz are supported
-                while (1)
-                    ;
-            }
+            // Fatal error: When using LoRa modem only bandwidths 125, 250 and 500 kHz are supported
+            MBED_ASSERT(bandwidth <= 2);
             bandwidth += 7;
             _rf_settings.lora.bandwidth = bandwidth;
             _rf_settings.lora.datarate = datarate;
@@ -1127,7 +1124,7 @@ void SX1276_LoRaRadio::set_tx_continuous_wave(uint32_t freq, int8_t power,
     uint8_t reg_val;
 
     set_channel(freq);
-    set_tx_config(MODEM_FSK, power, 0, 0, 4800, 0, 5, false, false, 0, 0, 0, time);
+    set_tx_config(MODEM_FSK, power, 0, 0, 4800, 0, 5, false, false, 0, 0, 0, time * 1000);
     reg_val = read_register(REG_PACKETCONFIG2);
 
     write_to_register( REG_PACKETCONFIG2, (reg_val & RF_PACKETCONFIG2_DATAMODE_MASK ) );
@@ -1136,7 +1133,7 @@ void SX1276_LoRaRadio::set_tx_continuous_wave(uint32_t freq, int8_t power,
     write_to_register( REG_DIOMAPPING2, RF_DIOMAPPING2_DIO4_10 | RF_DIOMAPPING2_DIO5_10 );
 
     _rf_settings.state = RF_TX_RUNNING;
-    tx_timeout_timer.attach_us(callback(this, &SX1276_LoRaRadio::timeout_irq_isr), time * 1000);
+    tx_timeout_timer.attach_us(callback(this, &SX1276_LoRaRadio::timeout_irq_isr), time * 1000000);
     set_operation_mode(RF_OPMODE_TRANSMITTER);
 }
 

--- a/SX1276/SX1276_LoRaRadio.h
+++ b/SX1276/SX1276_LoRaRadio.h
@@ -42,7 +42,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #ifdef MBED_CONF_SX1276_LORA_DRIVER_BUFFER_SIZE
 #define MAX_DATA_BUFFER_SIZE_SX1276                        MBED_CONF_SX1276_LORA_DRIVER_BUFFER_SIZE
 #else
-#define MAX_DATA_BUFFER_SIZE_SX1276                        256
+#define MAX_DATA_BUFFER_SIZE_SX1276                        255
 #endif
 
 /**
@@ -188,7 +188,7 @@ public:
      *  @param iq_inverted   Inverts IQ signals ( LoRa only )
      *                          FSK : N/A ( set to 0 )
      *                          LoRa: [0: not inverted, 1: inverted]
-     *  @param timeout       Transmission timeout [us]
+     *  @param timeout       Transmission timeout [ms]
      */
     virtual void set_tx_config(radio_modems_t modem, int8_t power, uint32_t fdev,
                               uint32_t bandwidth, uint32_t datarate,

--- a/SX1276/mbed_lib.json
+++ b/SX1276/mbed_lib.json
@@ -6,8 +6,8 @@
         	"value": 8000000
         },
         "buffer-size": {
-        	"help": "Max. buffer size the radio can handle, Default: 256 B",
-        	"value": 256
+        	"help": "Max. buffer size the radio can handle, Default: 255 B",
+        	"value": 255
         }
     }
 }


### PR DESCRIPTION
This commit fixes two issues reported in #24 and #25.
The default buffer size for the radio driver should have been 255 (0xFF) not 256.
In addition to that it was pointed out that the tx timer values were inconsistent
with the doc. All timer values are considered in ms except symbol timeout and the
time value for set_tx_continuous_wave() API.