### PR TITLE
Use Configuration to Set Variant Type if ant_switch Not Connected

### DIFF
--- a/SX1272/SX1272_LoRaRadio.cpp
+++ b/SX1272/SX1272_LoRaRadio.cpp
@@ -1466,7 +1466,7 @@ void SX1272_LoRaRadio::set_sx1272_variant_type()
         _ant_switch.output();
         wait_ms(1);
     } else {
-        radio_variant = SX1272UNDEFINED;
+        radio_variant = MBED_CONF_SX1272_LORA_DRIVER_RADIO_VARIANT;
     }
 }
 

--- a/SX1272/mbed_lib.json
+++ b/SX1272/mbed_lib.json
@@ -10,7 +10,7 @@
         	"value": 255
         },
         "radio-variant": {
-            "help": "Max. buffer size the radio can handle, Default: 255 B",
+            "help": "Use to set the radio variant if the antenna switch input is not connected.",
             "value": "SX1272UNDEFINED"
         }
     }

--- a/SX1272/mbed_lib.json
+++ b/SX1272/mbed_lib.json
@@ -8,6 +8,10 @@
         "buffer-size": {
         	"help": "Max. buffer size the radio can handle, Default: 255 B",
         	"value": 255
+        },
+        "radio-variant": {
+            "help": "Max. buffer size the radio can handle, Default: 255 B",
+            "value": "SX1272UNDEFINED"
         }
     }
 }

--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -1333,7 +1333,7 @@ void SX1276_LoRaRadio::set_sx1276_variant_type()
         _ant_switch.output();
         wait_ms(1);
     } else {
-        radio_variant = SX1276UNDEFINED;
+        radio_variant = MBED_CONF_SX1276_LORA_DRIVER_RADIO_VARIANT;
     }
 }
 

--- a/SX1276/mbed_lib.json
+++ b/SX1276/mbed_lib.json
@@ -8,6 +8,10 @@
         "buffer-size": {
         	"help": "Max. buffer size the radio can handle, Default: 255 B",
         	"value": 255
+        },
+        "radio-variant": {
+            "help": "Use to set the radio variant if the antenna switch input is not connected.",
+            "value": "SX1276UNDEFINED"
         }
     }
 }


### PR DESCRIPTION
Add configuration item to support different antenna configurations when not selecting using an 'antenna switch' input.
 
See [Setting the SX1276 Variant Type #27](https://github.com/ARMmbed/mbed-semtech-lora-rf-drivers/issues/27) for more discussion.