### PR TITLE
Adding support for low power timeouts

### DIFF
--- a/SX1272/SX1272_LoRaRadio.h
+++ b/SX1272/SX1272_LoRaRadio.h
@@ -31,7 +31,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "DigitalOut.h"
 #include "DigitalInOut.h"
 #include "SPI.h"
-#include "Timeout.h"
 #include "platform/PlatformMutex.h"
 #ifdef MBED_CONF_RTOS_PRESENT
  #include "rtos/Thread.h"
@@ -43,6 +42,14 @@ SPDX-License-Identifier: BSD-3-Clause
 #define MAX_DATA_BUFFER_SIZE_SX172                        MBED_CONF_SX1272_LORA_DRIVER_BUFFER_SIZE
 #else
 #define MAX_DATA_BUFFER_SIZE_SX172                        255
+#endif
+
+#if DEVICE_LPTICKER
+#include "LowPowerTimeout.h"
+#define ALIAS_LORAWAN_TIMER    mbed::LowPowerTimeout
+#else
+#include "Timeout.h"
+#define ALIAS_LORAWAN_TIMER    mbed::Timeout
 #endif
 
 /**
@@ -367,7 +374,7 @@ private:
     // If the chip fails to transmit, its a fatal error, reflecting
     // some catastrophic bus failure etc. We wish to have the control
     // back from the driver in such a case.
-    mbed::Timeout tx_timeout_timer;
+    ALIAS_LORAWAN_TIMER tx_timeout_timer;
 
 #ifdef MBED_CONF_RTOS_PRESENT
     // Thread to handle interrupts

--- a/SX1276/SX1276_LoRaRadio.h
+++ b/SX1276/SX1276_LoRaRadio.h
@@ -31,7 +31,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "DigitalOut.h"
 #include "DigitalInOut.h"
 #include "SPI.h"
-#include "Timeout.h"
 #include "platform/PlatformMutex.h"
 #ifdef MBED_CONF_RTOS_PRESENT
  #include "rtos/Thread.h"
@@ -43,6 +42,14 @@ SPDX-License-Identifier: BSD-3-Clause
 #define MAX_DATA_BUFFER_SIZE_SX1276                        MBED_CONF_SX1276_LORA_DRIVER_BUFFER_SIZE
 #else
 #define MAX_DATA_BUFFER_SIZE_SX1276                        255
+#endif
+
+#if DEVICE_LPTICKER
+#include "LowPowerTimeout.h"
+#define ALIAS_LORAWAN_TIMER    mbed::LowPowerTimeout
+#else
+#include "Timeout.h"
+#define ALIAS_LORAWAN_TIMER    mbed::Timeout
 #endif
 
 /**
@@ -382,7 +389,7 @@ private:
     // If the chip fails to transmit, its a fatal error, reflecting
     // some catastrophic bus failure etc. We wish to have the control
     // back from the driver in such a case.
-    mbed::Timeout tx_timeout_timer;
+    ALIAS_LORAWAN_TIMER tx_timeout_timer;
 
 #ifdef MBED_CONF_RTOS_PRESENT
     // Thread to handle interrupts


### PR DESCRIPTION
We had been on a mission to get rid of all the Timeout instances from
the radio drivers. However, 'tx_timeout' is a necessary evil which runs
every time we transmit so that we can inform the stack about any fatal
errors. The side effect of this Timeout is that it was using high-res
timeout which would lock the deep sleep and hence prevent the MCU to go
to deep sleep.

We have now added support for low power timeout and we check compile
time if the platform supports low power timeout to use it in the driver.
This means that now the 'tx_timeout' will not lock the deep sleep.