### PR TITLE
SX1276: Dynamic TCXO control

### DIFF
--- a/SX1276/SX1276_LoRaRadio.h
+++ b/SX1276/SX1276_LoRaRadio.h
@@ -336,6 +336,14 @@ public:
      */
     virtual void unlock(void);
 
+    /**
+     *  Set board specific TCXO parameters. This must be called before the radio
+     *  object is used.
+     *
+     *  @param tcxo_input_on        Enable TcxoInputOn setting in radio (external TCXO connected)
+     *  @param tcxo_wakeup_time     Time to TCXO startup [ms]
+     */
+    void set_board_tcxo_params(bool tcxo_input_on, uint32_t tcxo_wakeup_time);
 private:
 
     // SPI and chip select control
@@ -401,6 +409,10 @@ private:
 
     uint8_t radio_variant;
 
+    // TCXO
+    uint32_t _tcxo_wakeup_time;
+    bool _tcxo_input_on;
+
     // helper functions
     void setup_registers();
     void default_antenna_switch_ctrls();
@@ -426,6 +438,7 @@ private:
     void rf_irq_task(void);
     void set_modem(uint8_t modem);
     void rx_chain_calibration(void);
+    void set_board_tcxo(bool enable_tcxo);
 
     // ISRs
     void  dio0_irq_isr();


### PR DESCRIPTION
Two issues with TCXO on SX1276 resolved:
- If TCXO pin has been configured, TCXO is disabled when the radio goes
  to sleep.
- Set the TcxoInputOn bit properly and provide an interface to set the
  correct value for the particular board/SoC.

TCXO control is required for low-power applications; keeping it always enabled consumes ~1.2 mA which is unacceptable for most battery powered devices.

This might not be directly mergeable as such, but more like starting point... the main question is how the added member function set_board_tcxo_params() should be handled. Currently it's just a new non-virtual member function for this radio only. Options could be adding the parameter(s) to the constructor of SX1276_LoRaRadio or making the interface available in the virtual base class (LoRaRadio).

Also, I'm wondering if an explicit parameter for tcxo_input_on is really needed or should TcxoInputOn bit just become enabled always when a tcxo pin other than NC is given.

The logic for enabling/disabling the TCXO is modeled after LoRaMac-node where the dynamic TCXO enabling has been implemented.