### PR TITLE
Replace floating point with integer operations

### DIFF
--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -678,7 +678,7 @@ uint32_t SX1276_LoRaRadio::time_on_air(radio_modems_t modem, uint8_t pkt_len)
                                             != 0x00) ? 1 : 0) + pkt_len
                                     + ((_rf_settings.fsk.crc_on == 0x01) ?
                                             2 : 0));
-            airTime = (tmp / _rf_settings.fsk.datarate) + (((tmp % _rf_settings.fsk.datarate) > 0) ? 1 : 0);
+            airTime = (tmp / _rf_settings.fsk.datarate) + ((((tmp * 10) / _rf_settings.fsk.datarate) % 10 > 5) ? 1 : 0);
 
             break;
         case MODEM_LORA:

--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -1871,10 +1871,10 @@ void SX1276_LoRaRadio::handle_dio0_irq()
                     _rf_settings.fsk_packet_handler.rssi_value =
                             -(read_register(REG_RSSIVALUE) >> 1);
 
-                    _rf_settings.fsk_packet_handler.afc_value = (int32_t) (uint64_t) (
+                    _rf_settings.fsk_packet_handler.afc_value = (int32_t) ((uint64_t) (
                                     (((uint16_t) read_register(REG_AFCMSB) << 8) | (uint16_t) read_register(REG_AFCLSB))
                                     * (uint64_t) FREQ_STEP)
-                                    / FREQ_STEP_DECIMAL_POINTS;
+                                    / FREQ_STEP_DECIMAL_POINTS);
                     _rf_settings.fsk_packet_handler.rx_gain =
                                           (read_register( REG_LNA) >> 5) & 0x07;
 

--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -718,18 +718,18 @@ uint32_t SX1276_LoRaRadio::time_on_air(radio_modems_t modem, uint8_t pkt_len)
             }
 
             // Symbol rate : time for one symbol (secs)
-            uint32_t tPreamble = (uint32_t) (((uint64_t) (((_rf_settings.lora.preamble_len * 1000) + 4250) * (1 << _rf_settings.lora.datarate))) / bw); // unit = ms
+            uint32_t tPreamble = (uint32_t) ((uint64_t) (((_rf_settings.lora.preamble_len * 1000) + 4250) * (1 << _rf_settings.lora.datarate)) / bw); // unit = ms
 
             // Symbol length of payload and time
-            int64_t tmp1 = 1000 * 8 * pkt_len - 4 * _rf_settings.lora.datarate + 28 + 16 * _rf_settings.lora.crc_on - (_rf_settings.lora.fix_len ? 20 : 0);
+            int64_t tmp1 = 1000 * (8 * pkt_len - 4 * _rf_settings.lora.datarate + 28 + 16 * _rf_settings.lora.crc_on - (_rf_settings.lora.fix_len ? 20 : 0));
             int64_t tmp2 = 4 * (_rf_settings.lora.datarate - ((_rf_settings.lora.low_datarate_optimize > 0) ? 2 : 0));
             int32_t tmp3 = (int32_t) ((tmp1 / tmp2) + (((tmp1 % tmp2) > 0) ? 1 : 0));
             int32_t tmp  = (_rf_settings.lora.coderate + 4) * tmp3;
 
-            uint32_t nPayload = 8 + ((tmp > 0) ? tmp : 0);
+            uint32_t nPayload = 1000 * 8 + ((tmp > 0) ? tmp : 0);
             uint32_t tPayload = (nPayload * (1 << _rf_settings.lora.datarate)) / bw; // unit = ms
             // Time on air
-            airTime = tPreamble + tPayload;
+            airTime = (tPreamble + tPayload) / 1000; // unit = s
 
             break;
     }


### PR DESCRIPTION
The Mbed OS Core team has been investigating the usage of floating point in Mbed example projects. The goal is to remove floating point where possible to reduce the binary size on devices without an FPU.

This driver uses floating points but all instances can be replaced with equivalent integer operations without losing precision.

@hugueskamba @evedon @AnttiKauppila 