### PR TITLE
reduce default sx126x spi clock freq

### DIFF
--- a/SX126X/mbed_lib.json
+++ b/SX126X/mbed_lib.json
@@ -2,8 +2,8 @@
     "name": "SX126X-lora-driver",
     "config": {
         "spi-frequency": {
-        	"help": "SPI frequency, Default: 16 MHz",
-        	"value": 16000000
+        	"help": "SPI frequency, Default: 12 MHz",
+        	"value": 12000000
         },
         "buffer-size": {
         	"help": "Max. buffer size the radio can handle, Default: 255 B",


### PR DESCRIPTION
The absolute max SPI clock rate for the SX126x family is 16MHz.  This change reduces the default clock to 12MHz to provide some margin for MCU clock tolerances and pre/post-scaler rounding.

@AnttiKauppila 