### PR TITLE
Fix Fifo Pointer in Continuous Mode

### DIFF
--- a/SX1272/SX1272_LoRaRadio.cpp
+++ b/SX1272/SX1272_LoRaRadio.cpp
@@ -1824,6 +1824,7 @@ void SX1272_LoRaRadio::handle_dio0_irq()
                     }
 
                     _rf_settings.lora_packet_handler.size = read_register(REG_LR_RXNBBYTES);
+                    write_to_register(REG_LR_FIFOADDRPTR, read_register(REG_LR_FIFORXCURRENTADDR));
                     read_fifo(_data_buffer, _rf_settings.lora_packet_handler.size);
 
                     if (_rf_settings.lora.rx_continuous == false) {

--- a/SX1276/SX1276_LoRaRadio.cpp
+++ b/SX1276/SX1276_LoRaRadio.cpp
@@ -1973,6 +1973,7 @@ void SX1276_LoRaRadio::handle_dio0_irq()
                     }
 
                     _rf_settings.lora_packet_handler.size = read_register(REG_LR_RXNBBYTES);
+                    write_to_register(REG_LR_FIFOADDRPTR, read_register(REG_LR_FIFORXCURRENTADDR));
                     read_fifo(_data_buffer, _rf_settings.lora_packet_handler.size);
 
                     if (_rf_settings.lora.rx_continuous == false) {


### PR DESCRIPTION
In continuous mode we need to check and set the fifo pointer before every read, otherwise data may be lost.

This is bug is commonly seen when using the mbed LoRaWAN FUOTA demo as small delta updates working, but large full updates failing.

https://github.com/ARMmbed/mbed-os-example-lorawan-fuota/